### PR TITLE
Add a warning that useCheckbox should be used within a CheckboxContext

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,8 +12,13 @@ const CheckboxContext = React.createContext<CheckboxContextValue>({
   disabled: false,
 })
 
-export const useCheckbox = () =>
-  React.useContext<CheckboxContextValue>(CheckboxContext)
+export const useCheckbox = () => {
+  const context = React.useContext<CheckboxContextValue>(CheckboxContext)
+  if (context === undefined) {
+    throw new Error('useCheckbox must be used within a CheckboxContext')
+  }
+  return context
+}
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   (


### PR DESCRIPTION
Because I spend half an hour debugging after realising that I just accidentally self-closed the Checkbox component of @accessible/checkbox